### PR TITLE
pulled out CopySqliteOpenHelper from Room

### DIFF
--- a/daggercore/src/main/java/com/islamversity/daggercore/sqlitehelper/CopyLock.kt
+++ b/daggercore/src/main/java/com/islamversity/daggercore/sqlitehelper/CopyLock.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.islamversity.daggercore.sqlitehelper
+
+import androidx.annotation.RestrictTo
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.nio.channels.FileChannel
+import java.util.*
+import java.util.concurrent.locks.Lock
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+ * Utility class for in-process and multi-process key-based lock mechanism for safely copying
+ * database files.
+ *
+ *
+ * Acquiring the lock will be quick if no other thread or process has a lock with the same key.
+ * But if the lock is already held then acquiring it will block, until the other thread or process
+ * releases the lock. Note that the key and lock directory must be the same to achieve
+ * synchronization.
+ *
+ *
+ * Locking is done via two levels:
+ *
+ *  1.
+ * Thread locking within the same JVM process is done via a map of String key to ReentrantLock
+ * objects.
+ *  1.
+ * Multi-process locking is done via a lock file whose name contains the key and FileLock
+ * objects.
+ *
+ * @hide
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+class CopyLock(name: String, lockDir: File, processLock: Boolean) {
+    private val mCopyLockFile: File = File(lockDir, "$name.lck")
+    private val mThreadLock: Lock
+    private val mFileLevelLock: Boolean
+    private var mLockChannel: FileChannel? = null
+
+
+    /**
+     * Creates a lock with `name` and using `lockDir` as the directory for the
+     * lock files.
+     * @param name the name of this lock.
+     * @param lockDir the directory where the lock files will be located.
+     * @param processLock whether to use file for process level locking or not.
+     */
+    init {
+        mThreadLock = getThreadLock(mCopyLockFile.absolutePath)
+        mFileLevelLock = processLock
+    }
+
+    /**
+     * Attempts to grab the lock, blocking if already held by another thread or process.
+     */
+    fun lock() {
+        mThreadLock.lock()
+        if (mFileLevelLock) {
+            try {
+                mLockChannel = FileOutputStream(mCopyLockFile).channel
+                mLockChannel!!.lock()
+            } catch (e: IOException) {
+                throw IllegalStateException("Unable to grab copy lock.", e)
+            }
+        }
+    }
+
+    /**
+     * Releases the lock.
+     */
+    fun unlock() {
+        if (mLockChannel != null) {
+            try {
+                mLockChannel!!.close()
+            } catch (ignored: IOException) {
+            }
+        }
+        mThreadLock.unlock()
+    }
+}
+
+// in-process lock map
+private val sThreadLocks: MutableMap<String, Lock> =
+    HashMap()
+
+private fun getThreadLock(key: String): Lock {
+    synchronized(sThreadLocks) {
+        var threadLock = sThreadLocks[key]
+        if (threadLock == null) {
+            threadLock = ReentrantLock()
+            sThreadLocks[key] = threadLock
+        }
+        return threadLock
+    }
+}

--- a/daggercore/src/main/java/com/islamversity/daggercore/sqlitehelper/SQLiteCopyOpenHelper.kt
+++ b/daggercore/src/main/java/com/islamversity/daggercore/sqlitehelper/SQLiteCopyOpenHelper.kt
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.islamversity.daggercore.sqlitehelper
+
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import java.io.*
+import java.nio.ByteBuffer
+import java.nio.channels.Channels
+import java.nio.channels.FileChannel
+import java.nio.channels.ReadableByteChannel
+import java.util.concurrent.Callable
+
+private const val LOG_TAG = "SQLiteCopyOpenHelper"
+
+
+/**
+ * An open helper that will copy & open a pre-populated database if it doesn't exists in internal
+ * storage.
+ */
+class SQLiteCopyOpenHelper(
+    private val mContext: Context,
+    private val mCopyFromAssetPath: String?,
+    private val mCopyFromFile: File?,
+    private val mCopyFromInputStream: Callable<InputStream>?,
+    private val mDatabaseVersion: Int,
+    private val mDelegate: SupportSQLiteOpenHelper
+) : SupportSQLiteOpenHelper {
+    private var mVerified = false
+    override fun getDatabaseName(): String? {
+        return mDelegate.databaseName
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN)
+    override fun setWriteAheadLoggingEnabled(enabled: Boolean) {
+        mDelegate.setWriteAheadLoggingEnabled(enabled)
+    }
+
+    @Synchronized
+    override fun getWritableDatabase(): SupportSQLiteDatabase {
+        if (!mVerified) {
+            verifyDatabaseFile()
+            mVerified = true
+        }
+        return mDelegate.writableDatabase
+    }
+
+    @Synchronized
+    override fun getReadableDatabase(): SupportSQLiteDatabase {
+        if (!mVerified) {
+            verifyDatabaseFile()
+            mVerified = true
+        }
+        return mDelegate.readableDatabase
+    }
+
+    @Synchronized
+    override fun close() {
+        mDelegate.close()
+        mVerified = false
+    }
+
+    private fun verifyDatabaseFile() {
+        val databaseName = databaseName
+        val databaseFile = mContext.getDatabasePath(databaseName)
+        val copyLock = CopyLock(databaseName!!, mContext.filesDir, true)
+        try {
+            // Acquire a copy lock, this lock works across threads and processes, preventing
+            // concurrent copy attempts from occurring.
+            copyLock.lock()
+            if (!databaseFile.exists()) {
+                try {
+                    // No database file found, copy and be done.
+                    copyDatabaseFile(databaseFile)
+                    return
+                } catch (e: IOException) {
+                    throw RuntimeException("Unable to copy database file.", e)
+                }
+            }
+
+            // A database file is present, check if we need to re-copy it.
+            val currentVersion: Int = try {
+                readVersion(databaseFile)
+            } catch (e: IOException) {
+                Log.w(LOG_TAG, "Unable to read database version.", e)
+                return
+            }
+            if (currentVersion == mDatabaseVersion) {
+                return
+            }
+            if (currentVersion <= mDatabaseVersion) {
+                // From the current version to the desired version a migration is required, i.e.
+                // we won't be performing a copy destructive migration.
+                return
+            }
+            if (mContext.deleteDatabase(databaseName)) {
+                try {
+                    copyDatabaseFile(databaseFile)
+                } catch (e: IOException) {
+                    // We are more forgiving copying a database on a destructive migration since
+                    // there is already a database file that can be opened.
+                    Log.w(LOG_TAG, "Unable to copy database file.", e)
+                }
+            } else {
+                Log.w(
+                    LOG_TAG, "Failed to delete database file ("
+                            + databaseName + ") for a copy destructive migration."
+                )
+            }
+        } finally {
+            copyLock.unlock()
+        }
+    }
+
+    private fun copyDatabaseFile(destinationFile: File) {
+        val input: ReadableByteChannel
+        if (mCopyFromAssetPath != null) {
+            input = Channels.newChannel(mContext.assets.open(mCopyFromAssetPath))
+        } else if (mCopyFromFile != null) {
+            input = FileInputStream(mCopyFromFile).channel
+        } else if (mCopyFromInputStream != null) {
+            val inputStream: InputStream
+            inputStream = try {
+                mCopyFromInputStream.call()
+            } catch (e: Exception) {
+                throw IOException("inputStreamCallable exception on call", e)
+            }
+            input = Channels.newChannel(inputStream)
+        } else {
+            throw IllegalStateException(
+                "copyFromAssetPath, copyFromFile and "
+                        + "copyFromInputStream are all null!"
+            )
+        }
+
+        // An intermediate file is used so that we never end up with a half-copied database file
+        // in the internal directory.
+        val intermediateFile = File.createTempFile(
+            "room-copy-helper", ".tmp", mContext.cacheDir
+        )
+        intermediateFile.deleteOnExit()
+        val output = FileOutputStream(intermediateFile).channel
+        copy(input, output)
+        val parent = destinationFile.parentFile
+        if (parent != null && !parent.exists() && !parent.mkdirs()) {
+            throw IOException(
+                "Failed to create directories for "
+                        + destinationFile.absolutePath
+            )
+        }
+        if (!intermediateFile.renameTo(destinationFile)) {
+            throw IOException(
+                "Failed to move intermediate file ("
+                        + intermediateFile.absolutePath + ") to destination ("
+                        + destinationFile.absolutePath + ")."
+            )
+        }
+    }
+}
+
+/**
+ * Reads the user version number out of the database header from the given file.
+ *
+ * @param databaseFile the database file.
+ * @return the database version
+ * @throws IOException if something goes wrong reading the file, such as bad database header or
+ * missing permissions.
+ *
+ * @see [User Version
+ * Number](https://www.sqlite.org/fileformat.html.user_version_number).
+ */
+private fun readVersion(databaseFile: File): Int {
+    var input: FileChannel? = null
+    return try {
+        val buffer = ByteBuffer.allocate(4)
+        input = FileInputStream(databaseFile).channel
+        input.tryLock(60, 4, true)
+        input.position(60)
+        val read = input.read(buffer)
+        if (read != 4) {
+            throw IOException("Bad database header, unable to read 4 bytes at offset 60")
+        }
+        buffer.rewind()
+        buffer.int // ByteBuffer is big-endian by default
+    } finally {
+        input?.close()
+    }
+}
+
+/**
+ * Copies data from the input channel to the output file channel.
+ *
+ * @param input  the input channel to copy.
+ * @param output the output channel to copy.
+ * @throws IOException if there is an I/O error.
+ */
+private fun copy(input: ReadableByteChannel, output: FileChannel) {
+    try {
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
+            output.transferFrom(input, 0, Long.MAX_VALUE)
+        } else {
+            val inputStream = Channels.newInputStream(input)
+            val outputStream = Channels.newOutputStream(output)
+            var length: Int
+            val buffer = ByteArray(1024 * 4)
+            while (inputStream.read(buffer).also { length = it } > 0) {
+                outputStream.write(buffer, 0, length)
+            }
+        }
+        output.force(false)
+    } finally {
+        input.close()
+        output.close()
+    }
+}

--- a/daggercore/src/main/java/com/islamversity/daggercore/sqlitehelper/SQLiteCopyOpenHelperFactory.kt
+++ b/daggercore/src/main/java/com/islamversity/daggercore/sqlitehelper/SQLiteCopyOpenHelperFactory.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.islamversity.daggercore.sqlitehelper
+
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import java.io.File
+import java.io.InputStream
+import java.util.concurrent.Callable
+
+/**
+ * Implementation of [SupportSQLiteOpenHelper.Factory] that creates
+ * [SQLiteCopyOpenHelper].
+ */
+internal class SQLiteCopyOpenHelperFactory(
+    private val mCopyFromAssetPath: String?,
+    private val mCopyFromFile: File?,
+    private val mCopyFromInputStream: Callable<InputStream>?,
+    private val mDelegate: SupportSQLiteOpenHelper.Factory
+) : SupportSQLiteOpenHelper.Factory {
+    override fun create(configuration: SupportSQLiteOpenHelper.Configuration): SupportSQLiteOpenHelper {
+        return SQLiteCopyOpenHelper(
+            configuration.context,
+            mCopyFromAssetPath,
+            mCopyFromFile,
+            mCopyFromInputStream,
+            configuration.callback.version,
+            mDelegate.create(configuration)
+        )
+    }
+
+}


### PR DESCRIPTION
In order to load a prepopulated database in SQLDelight we have to copy it from assets to the correct position and then open it with the other tool.

[Room](https://github.com/androidx/androidx/blob/androidx-master-dev/room/runtime/src/main/java/androidx/room/SQLiteCopyOpenHelper.java) Already has that implementation and since SQLDelight Android driver is depending on `androidx.SupportSQLiteOpenHelper` we can copy the implementation from Room and wrap teh `FrameworkSQLiteOpenHelper` with it.
This way we copy the prepopulated database from assets only whenever the database is needed. the best part about Room approach is doing all this on a background thread so we don't have to block our main thread for a heavy file copy operation.

A sample usage of `SQLiteCopyOpenHelper` is like below:
```Kotlin
    val frameworkFactory = FrameworkSQLiteOpenHelperFactory()

    val callback = AndroidSqliteDriver.Callback(schema)

    val config = SupportSQLiteOpenHelper.Configuration.builder(context)
        .name("your database name")
        .callback(callback)
        .noBackupDirectory(false)
        .build()

    val openHelper = SQLiteCopyOpenHelperFactory(
        "asset adderss",
        null,
        null,
        frameworkFactory
    ).create(config)

    AndroidSqliteDriver(
        openHelper = openHelper
    )

//use the driver normally with SQLDelight

```